### PR TITLE
Fix event timestamp on Splunk

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -51,7 +51,7 @@ def lambda_handler(event, context):
         for line in cloudflare_response:
             
             jline = json.loads(line)
-            splunk_data = '{{"sourcetype": "cflogshare", "time":{}, "event":{}}}\n'.format(str(jline['EdgeStartTimestamp']),str(line))
+            splunk_data = '{{"sourcetype": "cflogshare", "time":{}, "event":{}}}\n'.format(str(jline['EdgeEndTimestamp']),str(line))
             splunk_batch += splunk_data
             
         splunk_request = requests.post(splunk_url, headers=splunk_headers, data=splunk_batch)


### PR DESCRIPTION
I just realized that the Cloudflare API start and end parameters were filtering the events based on EdgeEndTimestamp and not the EdgeStartTimestamp